### PR TITLE
fix dupe/voiding issues due to not marking the chunk dirty

### DIFF
--- a/src/main/java/tfar/craftingstation/CraftingStationBlockEntity.java
+++ b/src/main/java/tfar/craftingstation/CraftingStationBlockEntity.java
@@ -42,7 +42,7 @@ public class CraftingStationBlockEntity extends BlockEntity implements MenuProvi
 
   public CraftingStationBlockEntity(BlockPos pPos, BlockState pState) {
     super(ModBlockEntityTypes.crafting_station,pPos,pState);
-    this.input = new CraftingStationItemHandler(9);
+    this.input = new CraftingStationItemHandler(9, this);
   }
 
   @Nonnull

--- a/src/main/java/tfar/craftingstation/util/CraftingStationItemHandler.java
+++ b/src/main/java/tfar/craftingstation/util/CraftingStationItemHandler.java
@@ -3,10 +3,15 @@ package tfar.craftingstation.util;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.NonNullList;
 import net.minecraftforge.items.ItemStackHandler;
+import tfar.craftingstation.CraftingStationBlockEntity;
 
 public class CraftingStationItemHandler extends ItemStackHandler {
-  public CraftingStationItemHandler(int size){
+
+  CraftingStationBlockEntity craftingStationBlockEntity;
+  
+  public CraftingStationItemHandler(int size, CraftingStationBlockEntity craftingStationBlockEntity){
     super(size);
+    this.craftingStationBlockEntity = craftingStationBlockEntity;
   }
 
   public NonNullList<ItemStack> getContents(){
@@ -15,5 +20,11 @@ public class CraftingStationItemHandler extends ItemStackHandler {
 
   public boolean isEmpty(){
     return getContents().stream().allMatch(ItemStack::isEmpty);
+  }
+
+  @Override
+  protected void onContentsChanged(int slot) {
+    this.craftingStationBlockEntity.setChanged();
+    super.onContentsChanged(slot);
   }
 }


### PR DESCRIPTION
after picking up/placing items in the crafting table set the chunk to be saved.
depending on the timing it can either void or dupe the items placed on the table after unloading the chunk the table is in
