### PR TITLE
Filter out empty slots before sending to JEI.

### DIFF
--- a/src/main/java/tfar/craftingstation/jei/CraftingStationTransferInfo.java
+++ b/src/main/java/tfar/craftingstation/jei/CraftingStationTransferInfo.java
@@ -27,7 +27,7 @@ public class CraftingStationTransferInfo implements IRecipeTransferInfo<Crafting
 
   @Override
   public List<Slot> getInventorySlots(CraftingStationContainer container,CraftingRecipe recipe) {
-    return IntStream.range(10,container.slots.size() ).mapToObj(container::getSlot).collect(Collectors.toList());
+    return IntStream.range(10,container.slots.size() ).mapToObj(container::getSlot).filter(s -> s.hasItem()).collect(Collectors.toList());
   }
 
   @Override


### PR DESCRIPTION
Later versions of JEI check each slot with mayPickup().  Forge's SlotItemHandler will return false for mayPickup() if the slot is empty.  This caused JEI to reject the inventories for use as holders of ingredients.

Fixes #104